### PR TITLE
Fix broken Heroku deploy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ DEPENDENCIES
   sinatra
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.4p191
 
 BUNDLED WITH
    2.2.31


### PR DESCRIPTION
It was broken because the Gemfile.lock had not been updated with the
change of Ruby version in the previous commit.  The fix was to run:
`bundle update --ruby`.