### PR TITLE
Fix default vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,6 @@
-{}
+{
+    "files.associations": {
+        "*.spec": "gauge",
+        "*.cpt": "gauge"
+    }
+}


### PR DESCRIPTION
The previous commit did not include the proper settings, by mistake.