### PR TITLE
Replace Hello World with available pets from API

### DIFF
--- a/functional-tests/specs/available_pets.spec
+++ b/functional-tests/specs/available_pets.spec
@@ -1,6 +1,5 @@
-# Available pets
+# Pet store availability
 
-* Open available pets application
+## Customers can see which pets are available in the pet store
 
-## Hello world
-* Must display "Hello world!"
+* There is a pet named "doggie" available in the pet store

--- a/functional-tests/tests/step_implementation.js
+++ b/functional-tests/tests/step_implementation.js
@@ -43,11 +43,8 @@ gauge.customScreenshotWriter = async function () {
     return path.basename(screenshotFilePath);
 };
 
-step("Open available pets application", async function () {
+
+step("There is a pet named <petName> available in the pet store", async function (petName) {
     await goto(process.env.WEB_URL);
-});
-
-
-step("Must display <message>", async function (message) {
-    assert.ok(await text(message).exists(0, 0));
+    assert.ok(await text(petName).exists(0, 0));
 });

--- a/myapp.rb
+++ b/myapp.rb
@@ -1,5 +1,14 @@
 require 'sinatra'
+require 'net/http'
+require 'json'
 
-get '/' do
-  'Hello world!'
+get('/') do
+  pets.filter_map { |pet| "#{pet['name']}<br />" unless pet['name'].nil? }
+end
+
+def pets
+  url = 'https://petstore.swagger.io/v2/pet/findByStatus?status=available'
+  uri = URI(url)
+  response = Net::HTTP.get(uri)
+  JSON.parse(response)
 end


### PR DESCRIPTION
This commit sees us getting rid of the irrelevant Hello World content
and replacing it with the names of available pets, consumed from the
provider API.

The provider API URL is hardcoded to be the production API URL.  In a
future PR we will externalise the URL to be configurable, so that we can
use [Prism][1] to mock the API call when running the functional tests
on pull request Review Apps.

[1]: https://stoplight.io/open-source/prism/