### PR TITLE
Use Prism mock instead of real API

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,7 +19,7 @@ ARG CHROMIUM_VERSION="none"
 RUN gem install bundler rubocop
 
 # [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g @stoplight/prism-cli" 2>&1
 
 # Install gauge and gauge plugins
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/config.ru
+++ b/config.ru
@@ -1,2 +1,4 @@
+$stdout.sync = true
+
 require './myapp'
 run Sinatra::Application

--- a/myapp.rb
+++ b/myapp.rb
@@ -7,7 +7,22 @@ get('/') do
 end
 
 def pets
-  url = "#{ENV['PETSTORE_URL']}pet/findByStatus?status=available"
-  response = Net::HTTP.get(URI(url))
-  JSON.parse(response)
+  get_json "#{petstore_url}pet/findByStatus?status=available"
+end
+
+def get_json(url)
+  uri = URI(url)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true if uri.instance_of? URI::HTTPS
+  request = Net::HTTP::Get.new(uri.request_uri)
+  request['Accept'] = 'application/json'
+  request['authorization'] = 'Bearer YOUR_ACCESS_TOKEN'
+  response = http.request(request)
+  JSON.parse(response.body)
+end
+
+def petstore_url
+  petstore_url = ENV['PETSTORE_URL']
+  puts "Petstore URL is #{petstore_url}"
+  petstore_url
 end


### PR DESCRIPTION
One interesting thing about this is that when we used Prism to mock the
API call, it instantly flagged that we were missing the required
authorization header in our request (we ran Prism with the `--errors`
flag which is something we should always do, to discover errors like
this).

This switch to use the Prism mock simply involved changing the
`PETSTORE_URL` environment variable to point to Prism, i.e.
`http://127.0.0.1:4010/` when running locally, and setting up a
[Stoplight hosted Prism mock][1] when running on a Review App, i.e.
`https://stoplight.io/mocks/agilepathway/java-openapi-provider/84330/`.

In a later commit we'll setup the URL to be dynamic based on the Git
branch, so that we can use an individual Prism mock server for every
branch.

[1]: https://meta.stoplight.io/docs/platform/ZG9jOjIwMTI4MA-working-with-mock-servers