### PR TITLE
Make deployments to Heroku sequential

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -20,6 +20,7 @@ jobs:
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
 
   deploy-to-production:
+    needs: deploy-to-pre-production
     runs-on: ubuntu-20.04
     environment: production
     steps:


### PR DESCRIPTION
Prior to this commit the deploys to production and pre-production were
happening in parallel.  Now the deploy to production only happens once
the deploy to pre-production has succeeded.