### PR TITLE
Use branch-specific mock server on review apps

### DIFF
--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -29,6 +29,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set PETSTORE_URL output var
+        id: set-petstore-url-output-var
+        run: |
+          PROVIDER_REPO=https://github.com/agilepathway/java-openapi-provider
+          PROVIDER_BRANCH=${GITHUB_HEAD_REF}
+          if ! git ls-remote --exit-code --heads $PROVIDER_REPO ${PROVIDER_BRANCH}; then
+            PROVIDER_BRANCH=master
+          fi
+          MOCK_SERVER_BASE_URL=https://stoplight.io/mocks/agilepathway/java-openapi-provider
+          MOCK_SERVER_ID=84330
+          PETSTORE_URL=${{ format('{0}:{1}/{2}/', '$MOCK_SERVER_BASE_URL', '${PROVIDER_BRANCH}', '${MOCK_SERVER_ID}') }}
+          echo "::set-output name=petstore-url::${PETSTORE_URL}"
+
+      - name: Set PETSTORE_URL config var on Heroku
+        run: |
+          heroku config:set \
+            PETSTORE_URL="${{ steps.set-petstore-url-output-var.outputs.petstore-url }}" \
+            --app ${{ steps.review_app_status.outputs.review_app_name }}
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+
       - name: FTs
         env:
           WEB_URL: ${{ steps.review_app_status.outputs.review_app_url }}


### PR DESCRIPTION
Prior to this commit the Prism mock server that is used on our pull
request triggered [Review Apps][1] was always based on the trunk branch
of the [provider repo][2] (which has the OpenApi spec that the Prism
mock server is based on).  Now in our pull request CI/CD pipeline we
will use a Prism mock server based on the matching git branch of the
provider repo, defaulting to the trunk repo if there is no matching git
branch.

This means that when the consumer wants to request a change to the
provider's OpenAPI spec (through our
[consumer-driven-contract-testing][3] approach), the consumer can go
ahead and create a branch on the provider app's repo with the change -
then allowing the consumer to run their tests against the proposed
change on the Review App.  So in short this is a big enabler for a real
consumer-driven approach.

[1]: https://devcenter.heroku.com/articles/github-integration-review-apps
[2]: https://github.com/agilepathway/java-openapi-provider
[3]: https://martinfowler.com/articles/consumerDrivenContracts.html