### PR TITLE
Tag trunk commits with contract repo HEAD commit

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -21,4 +21,4 @@ jobs:
         uses: mristin/opinionated-commit-message@v2.2.0
         with:
           allow-one-liners: 'true'
-          additional-verbs: 'export, parse, append, skip, store, retry, tidy, exit, deploy, verify'
+          additional-verbs: 'export, parse, append, skip, store, retry, tidy, exit, deploy, verify, tag'

--- a/.github/workflows/trunk-pipeline.yml
+++ b/.github/workflows/trunk-pipeline.yml
@@ -43,6 +43,28 @@ jobs:
           name: post-merge-fts-logs
           path: functional-tests/logs
 
+      - name: Set contract repo HEAD output var
+        id: set-contract-head-output-var
+        # NB we append the date time to the tag to make it unique,
+        # as multiple commits can be linked to the same contract repo commit
+        run: |
+          CONTRACT_REPO=https://github.com/agilepathway/available-pets-consumer-contract
+          CONTRACT_HEAD=$(git ls-remote --heads $CONTRACT_REPO refs/heads/master | head -c 7)
+          DATETIME=$(date '+%Y-%m-%d-%H-%M-%S')
+          echo "::set-output name=contract-head::${CONTRACT_HEAD}-available-pets-consumer-contract-${DATETIME}"
+
+      - name: Tag commit with HEAD commit from contract repo
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ steps.set-contract-head-output-var.outputs.contract-head }}",
+              sha: context.sha
+            })
+
 
   deploy-to-pre-production:
     needs: deploy-to-post-merge


### PR DESCRIPTION
The CI/CD pipeline now tags any commit to trunk (i.e. any merge to the
trunk branch) (which has successfully run the post-merge contract tests)
with the HEAD commit SHA of the contract repo.  This is so that we can
check that the provider in any of our integrated environments is
compatible with the contract that the consumer needs, before deploying
to that integrated environment.

For example, if we have amended the contract with a new feature but the
provider has not yet added their implementation of this new feature to
production, then we will be able to set up our CI/CD (in a future PR to
come after this one) to fail the build (by running the contract tests
for the contract demanded by the consumer against a mock provider using
the provider commit that is in production) and therefore correctly
prevent us deploying the consumer to production.

When we tag the trunk commit we append the date and time to the end of
the tag.  This is because tags have to be unique, and multiple commits
can be linked to the same contract repo commit.