### PR TITLE
Tag the full SHA not the short SHA

### DIFF
--- a/.github/workflows/trunk-pipeline.yml
+++ b/.github/workflows/trunk-pipeline.yml
@@ -49,7 +49,7 @@ jobs:
         # as multiple commits can be linked to the same contract repo commit
         run: |
           CONTRACT_REPO=https://github.com/agilepathway/available-pets-consumer-contract
-          CONTRACT_HEAD=$(git ls-remote --heads $CONTRACT_REPO refs/heads/master | head -c 7)
+          CONTRACT_HEAD=($(git ls-remote --heads $CONTRACT_REPO refs/heads/master))
           DATETIME=$(date '+%Y-%m-%d-%H-%M-%S')
           echo "::set-output name=contract-head::${CONTRACT_HEAD}-available-pets-consumer-contract-${DATETIME}"
 


### PR DESCRIPTION
GitHub's [Checkout action][1] needs the [full SHA in order to checkout a
commit][2].

To get the full SHA we simply use a [bash array][3] which outputs its
first element.

[1]: https://github.com/actions/checkout
[2]: https://github.com/actions/checkout/issues/265
[3]: https://opensource.com/article/18/5/you-dont-know-bash-intro-bash-arrays