### PR TITLE
Amend format of contract tag for easier lookup

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -21,4 +21,4 @@ jobs:
         uses: mristin/opinionated-commit-message@v2.2.0
         with:
           allow-one-liners: 'true'
-          additional-verbs: 'export, parse, append, skip, store, retry, tidy, exit, deploy, verify, tag'
+          additional-verbs: 'export, parse, append, skip, store, retry, tidy, exit, deploy, verify, tag, amend'

--- a/.github/workflows/trunk-pipeline.yml
+++ b/.github/workflows/trunk-pipeline.yml
@@ -51,7 +51,7 @@ jobs:
           CONTRACT_REPO=https://github.com/agilepathway/available-pets-consumer-contract
           CONTRACT_HEAD=($(git ls-remote --heads $CONTRACT_REPO refs/heads/master))
           DATETIME=$(date '+%Y-%m-%d-%H-%M-%S')
-          echo "::set-output name=contract-head::${CONTRACT_HEAD}-available-pets-consumer-contract-${DATETIME}"
+          echo "::set-output name=contract-head::available-pets-consumer-contract-${CONTRACT_HEAD}-${DATETIME}"
 
       - name: Tag commit with HEAD commit from contract repo
         uses: actions/github-script@v5


### PR DESCRIPTION
By now having the git tag always start with
"available-pets-consumer-contract", it will be easier to lookup the tag
whenever we want to retrieve it (as we'll be able to use [git
describe's match functionality][1]).

[1]: https://git-scm.com/docs/git-describe#Documentation/git-describe.txt---matchltpatterngt