### PR TITLE
Use our own provider when using validation proxy

### DIFF
--- a/.github/workflows/trunk-pipeline.yml
+++ b/.github/workflows/trunk-pipeline.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Start Prism in validation proxy mode
         working-directory: ./contract
-        run: prism proxy openapi.yaml https://petstore.swagger.io/v2 --errors &
+        run: prism proxy openapi.yaml https://petstore-openapi-service.herokuapp.com/v2 --errors &
 
       - name: Check that the provider in production satisfies the contract
         env:


### PR DESCRIPTION
Prior to this commit we were using the [generic Petstore server][1] when
running Prism in validation proxy mode.  Now that we have [our own
provider][2] we can specify its URL instead.

[1]: https://petstore.swagger.io
[2]: https://github.com/agilepathway/petstore-service