### PR TITLE
Fix `can-i-deploy` ephemeral env deploy

### DIFF
--- a/.github/workflows/trunk-pipeline.yml
+++ b/.github/workflows/trunk-pipeline.yml
@@ -77,6 +77,8 @@ jobs:
         run: |
           COMMIT=$(heroku config:get --app petstore-openapi-service HEROKU_SLUG_COMMIT)
           echo "::set-output name=commit::${COMMIT}"
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
 
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
Add the `HEROKU_API_KEY` which was omitted by mistake from the previous
commit.